### PR TITLE
refactor: split main.rs into modular architecture

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,82 @@
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+pub struct ProgressLogger {
+    progress_bar: ProgressBar,
+    video_progress_bar: Option<ProgressBar>, // Video encoding progress
+}
+
+impl ProgressLogger {
+    pub fn new(total_files: u64, multi_progress: &MultiProgress) -> Self {
+        // Create main progress bar
+        let progress_bar = multi_progress.add(ProgressBar::new(total_files));
+        progress_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} files (ETA: {eta})")
+                .unwrap()
+                .progress_chars("#>-"),
+        );
+
+        Self {
+            progress_bar,
+            video_progress_bar: None,
+        }
+    }
+
+    pub fn inc(&mut self) {
+        self.progress_bar.inc(1);
+    }
+
+    pub fn start_video_progress(&mut self, filename: &str, multi_progress: &MultiProgress) {
+        let video_bar = multi_progress.add(ProgressBar::new(100));
+        video_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.blue} Encoding {msg}: [{wide_bar:.yellow/blue}] {percent}%")
+                .unwrap()
+                .progress_chars("#>-"),
+        );
+        video_bar.set_message(filename.to_string());
+        self.video_progress_bar = Some(video_bar);
+    }
+
+    pub fn finish_video_progress(&mut self) {
+        if let Some(bar) = self.video_progress_bar.take() {
+            bar.finish_and_clear();
+        }
+    }
+
+    pub fn finish(&mut self) {
+        // Finish video progress bar if still active
+        self.finish_video_progress();
+
+        // Finish and clear the main progress bar
+        self.progress_bar.finish_and_clear();
+    }
+
+    pub fn video_progress_bar(&self) -> Option<&ProgressBar> {
+        self.video_progress_bar.as_ref()
+    }
+}
+
+/// Get ANSI color code for log level
+pub const fn get_log_color(level: log::Level) -> &'static str {
+    match level {
+        log::Level::Error => "\x1b[91m",                     // Red
+        log::Level::Warn => "\x1b[33m",                      // Orange-red/Yellow
+        log::Level::Info => "\x1b[32m",                      // Darker green (same as Cargo)
+        log::Level::Debug | log::Level::Trace => "\x1b[90m", // Grey
+    }
+}
+
+/// Get ANSI color code for log level with module-specific overrides
+pub fn get_log_color_with_module(level: log::Level, module_path: Option<&str>) -> &'static str {
+    // Special handling for Symphonia library messages
+    if let Some(module) = module_path {
+        if module.starts_with("symphonia") && level == log::Level::Info {
+            // Make Symphonia info messages gray to reduce visual noise
+            return "\x1b[90m"; // Grey
+        }
+    }
+
+    // Use default color for all other cases
+    get_log_color(level)
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,209 @@
+/// Statistics tracking for compression operations
+#[derive(Debug, Default)]
+pub struct CompressionStats {
+    // Image statistics
+    images_processed: u32,
+    images_skipped: u32,
+    images_kept_original: u32,
+    image_original_size: u64,
+    image_compressed_size: u64,
+
+    // Audio statistics
+    audio_processed: u32,
+    audio_skipped: u32,
+    audio_kept_original: u32,
+    audio_original_size: u64,
+    audio_compressed_size: u64,
+
+    // Video statistics
+    video_processed: u32,
+    video_skipped: u32,
+    video_kept_original: u32,
+    video_original_size: u64,
+    video_compressed_size: u64,
+
+    // Overall statistics
+    total_input_size: u64,
+    total_output_size: u64,
+    total_updated_refs: u32,
+}
+
+impl CompressionStats {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // Image tracking methods
+    pub fn add_processed_image(&mut self, original_size: u64, compressed_size: u64) {
+        self.images_processed += 1;
+        self.image_original_size += original_size;
+        self.image_compressed_size += compressed_size;
+        self.total_input_size += original_size;
+        self.total_output_size += compressed_size;
+    }
+
+    pub fn add_kept_original_image(&mut self, size: u64) {
+        self.images_kept_original += 1;
+        self.image_original_size += size;
+        self.image_compressed_size += size;
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    pub fn add_skipped_image(&mut self, size: u64) {
+        self.images_skipped += 1;
+        self.image_original_size += size;
+        self.image_compressed_size += size;
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    // Audio tracking methods
+    pub fn add_processed_audio(&mut self, original_size: u64, compressed_size: u64) {
+        self.audio_processed += 1;
+        self.audio_original_size += original_size;
+        self.audio_compressed_size += compressed_size;
+        self.total_input_size += original_size;
+        self.total_output_size += compressed_size;
+    }
+
+    pub fn add_kept_original_audio(&mut self, size: u64) {
+        self.audio_kept_original += 1;
+        self.audio_original_size += size;
+        self.audio_compressed_size += size;
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    pub fn add_skipped_audio(&mut self, size: u64) {
+        self.audio_skipped += 1;
+        self.audio_original_size += size;
+        self.audio_compressed_size += size;
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    // Video tracking methods
+    pub fn add_processed_video(&mut self, original_size: u64, compressed_size: u64) {
+        self.video_processed += 1;
+        self.video_original_size += original_size;
+        self.video_compressed_size += compressed_size;
+        self.total_input_size += original_size;
+        self.total_output_size += compressed_size;
+    }
+
+    pub fn add_kept_original_video(&mut self, size: u64) {
+        self.video_kept_original += 1;
+        self.video_original_size += size;
+        self.video_compressed_size += size;
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    pub fn add_skipped_video(&mut self, size: u64) {
+        self.video_skipped += 1;
+        self.video_original_size += size;
+        self.video_compressed_size += size;
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    // Other file tracking
+    pub fn add_other_file(&mut self, size: u64) {
+        self.total_input_size += size;
+        self.total_output_size += size;
+    }
+
+    pub fn add_updated_refs(&mut self, count: u32) {
+        self.total_updated_refs += count;
+    }
+
+    // Calculation methods
+    pub fn total_compression_ratio(&self) -> f64 {
+        if self.total_input_size > 0 {
+            (1.0 - self.total_output_size as f64 / self.total_input_size as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    pub fn image_compression_ratio(&self) -> f64 {
+        if self.image_original_size > 0 {
+            (1.0 - self.image_compressed_size as f64 / self.image_original_size as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    pub fn audio_compression_ratio(&self) -> f64 {
+        if self.audio_original_size > 0 {
+            (1.0 - self.audio_compressed_size as f64 / self.audio_original_size as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    pub fn video_compression_ratio(&self) -> f64 {
+        if self.video_original_size > 0 {
+            (1.0 - self.video_compressed_size as f64 / self.video_original_size as f64) * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    // Getter methods for public access to statistics
+    pub fn images_processed(&self) -> u32 {
+        self.images_processed
+    }
+    pub fn images_skipped(&self) -> u32 {
+        self.images_skipped
+    }
+    pub fn images_kept_original(&self) -> u32 {
+        self.images_kept_original
+    }
+    pub fn image_original_size(&self) -> u64 {
+        self.image_original_size
+    }
+    pub fn image_compressed_size(&self) -> u64 {
+        self.image_compressed_size
+    }
+
+    pub fn audio_processed(&self) -> u32 {
+        self.audio_processed
+    }
+    pub fn audio_skipped(&self) -> u32 {
+        self.audio_skipped
+    }
+    pub fn audio_kept_original(&self) -> u32 {
+        self.audio_kept_original
+    }
+    pub fn audio_original_size(&self) -> u64 {
+        self.audio_original_size
+    }
+    pub fn audio_compressed_size(&self) -> u64 {
+        self.audio_compressed_size
+    }
+
+    pub fn video_processed(&self) -> u32 {
+        self.video_processed
+    }
+    pub fn video_skipped(&self) -> u32 {
+        self.video_skipped
+    }
+    pub fn video_kept_original(&self) -> u32 {
+        self.video_kept_original
+    }
+    pub fn video_original_size(&self) -> u64 {
+        self.video_original_size
+    }
+    pub fn video_compressed_size(&self) -> u64 {
+        self.video_compressed_size
+    }
+
+    pub fn total_input_size(&self) -> u64 {
+        self.total_input_size
+    }
+    pub fn total_output_size(&self) -> u64 {
+        self.total_output_size
+    }
+}

--- a/src/video.rs
+++ b/src/video.rs
@@ -349,7 +349,7 @@ pub fn compress_video_file(
             }
             FfmpegEvent::Progress(progress) => {
                 // Update video progress bar using hybrid frame/time-based calculation
-                if let Some(video_bar) = &logger.video_progress_bar {
+                if let Some(video_bar) = logger.video_progress_bar() {
                     match calculate_video_progress(progress.frame, &progress.time, &metadata) {
                         Some(progress_percent) => {
                             // Accurate progress available - set position


### PR DESCRIPTION
## Summary
- Extract CompressionStats to dedicated src/stats.rs module
- Extract ProgressLogger and logging utilities to src/progress.rs module  
- Add proper encapsulation with private fields and public getter methods

## Test plan
- [x] All existing tests pass (18/18)
- [x] Code builds without warnings
- [x] Clippy passes without issues
- [x] Formatting is consistent